### PR TITLE
fix: include 'locality' in geocoding and autocomplete type enum

### DIFF
--- a/api-specs/geocoding/address_autocomplete.yaml
+++ b/api-specs/geocoding/address_autocomplete.yaml
@@ -65,7 +65,7 @@ paths:
             - `locality`: Search for administrative areas, which can include postcodes, districts, cities, counties, and states.
           schema:
             type: string
-            enum: [ country, state, city, postcode, street, amenity ]
+            enum: [ country, state, city, postcode, street, amenity, locality ]
             example: "city"
         - name: limit
           in: query

--- a/api-specs/geocoding/batch_geocoding.yaml
+++ b/api-specs/geocoding/batch_geocoding.yaml
@@ -50,7 +50,7 @@ paths:
             - `locality`: Search for administrative areas, which can include postcodes, districts, cities, counties, and states.
           schema:
             type: string
-            enum: [ country, state, city, postcode, street, amenity ]
+            enum: [ country, state, city, postcode, street, amenity, locality ]
         - name: lang
           in: query
           required: false
@@ -254,7 +254,7 @@ paths:
             - `locality`: Search for administrative areas, which can include postcodes, districts, cities, counties, and states.
           schema:
             type: string
-            enum: [ country, state, city, postcode, street, amenity ]
+            enum: [ country, state, city, postcode, street, amenity, locality ]
         - name: lang
           in: query
           required: false

--- a/api-specs/geocoding/forward_geocoding.yaml
+++ b/api-specs/geocoding/forward_geocoding.yaml
@@ -110,7 +110,7 @@ paths:
             - `locality`: Search for administrative areas, which can include postcodes, districts, cities, counties, and states.
           schema:
             type: string
-            enum: [ country, state, city, postcode, street, amenity ]
+            enum: [ country, state, city, postcode, street, amenity, locality ]
         - name: lang
           in: query
           required: false


### PR DESCRIPTION
### Description
This PR fixes a schema validation issue in the Geocoding APIs (Forward, Batch, and Address Autocomplete).

### Changes
- Added `locality` to the `enum` list for the `type` parameter.

### Reason
The `locality` parameter was clearly described in the documentation comments (`Search for administrative areas...`), but it was missing from the validation schema (`enum`). This caused valid requests asking for `type=locality` to potentially fail validation or be flagged as incorrect by OpenAPI tools.